### PR TITLE
stream_read must return "" on eof (false means error)

### DIFF
--- a/lib/Horde/Stream/Wrapper/Combine.php
+++ b/lib/Horde/Stream/Wrapper/Combine.php
@@ -159,7 +159,7 @@ class Horde_Stream_Wrapper_Combine
     public function stream_read($count)
     {
         if ($this->stream_eof()) {
-            return false;
+            return "";
         }
 
         $out = '';


### PR DESCRIPTION
fix needed for PHP 7.4 since commit « Report errors from stream read and write operations » d59aac58b3e7da7ad01a194fe9840d89725ea229

it especially fixes file_put_contents in imp addAttachmentFromPart on PHP 7.4